### PR TITLE
Backport fix from https://github.com/miguelbalboa/rfid.git commit 4ac9700e

### DIFF
--- a/src/MFRC522Extended.cpp
+++ b/src/MFRC522Extended.cpp
@@ -821,7 +821,7 @@ MFRC522::StatusCode MFRC522Extended::TCL_Transceive(TagInfo *tag, byte *sendData
 	// Swap block number on success
 	tag->blockNumber = !tag->blockNumber;
 
-	if (backData && (backLen > 0)) {
+	if (backData && (*backLen > 0)) {
 		if (*backLen < in.inf.size)
 			return STATUS_NO_ROOM;
 
@@ -844,7 +844,7 @@ MFRC522::StatusCode MFRC522Extended::TCL_Transceive(TagInfo *tag, byte *sendData
 		if (result != STATUS_OK)
 			return result;
 
-		if (backData && (backLen > 0)) {
+		if (backData && (*backLen > 0)) {
 			if ((*backLen + ackDataSize) > totalBackLen)
 				return STATUS_NO_ROOM;
 


### PR DESCRIPTION
Fix: Correct pointer comparison issue in MFRC522Extended.cpp

- Fixed an issue in `MFRC522Extended.cpp` where the code incorrectly compared a pointer (`backLen`) with an integer.
- Modified the conditional statements at lines 824 and 847 to properly check if `backLen` is not null and its value is greater than zero.
- This resolves compilation errors related to ordered comparison of pointers with integers in the MFRC522 library.

<!-- BEGIN - This is a comment just for you visible

Please use the following template to give us as much information as you can.
Not used rows can be deleted.

Please create just PRs wiht fixes/typos or documentation updates; no extensions for other boards; no new examples. See development status.

END - This is a comment just for you visible -->

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no <!-- BC = backwards compatibility -->
| Deprecations? | no
| Fixed tickets | <!-- #-prefixed issue number(s), if any -->
